### PR TITLE
✨ Interface Consistency: Standardize CLI patterns for Conduit integration

### DIFF
--- a/src/Concerns/HandlesSpotifyOutput.php
+++ b/src/Concerns/HandlesSpotifyOutput.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace JordanPartridge\ConduitSpotify\Concerns;
+
+/**
+ * Provides consistent output formatting for Spotify commands
+ * Supports both interactive and JSON formats for human and programmatic use
+ */
+trait HandlesSpotifyOutput
+{
+    /**
+     * Output data in JSON format with consistent structure
+     */
+    protected function outputJson(array $data, int $exitCode = 0): int
+    {
+        $response = [
+            'timestamp' => now()->toISOString(),
+            'command' => $this->getName(),
+            'success' => $exitCode === 0,
+            'data' => $data,
+        ];
+
+        $this->output->writeln(json_encode($response, JSON_PRETTY_PRINT));
+
+        return $exitCode;
+    }
+
+    /**
+     * Handle API errors with consistent formatting
+     */
+    protected function handleApiError(\Exception $e, ?string $context = null): int
+    {
+        $error = [
+            'error' => $e->getMessage(),
+            'type' => get_class($e),
+        ];
+
+        if ($context) {
+            $error['context'] = $context;
+        }
+
+        if ($this->option('format') === 'json') {
+            return $this->outputJson($error, 1);
+        }
+
+        $this->error("❌ {$e->getMessage()}");
+
+        return 1;
+    }
+
+    /**
+     * Handle authentication errors with consistent messaging
+     */
+    protected function handleAuthError(): int
+    {
+        $error = [
+            'error' => 'Not authenticated with Spotify',
+            'action' => 'Run: conduit spotify:login',
+        ];
+
+        if ($this->option('format') === 'json') {
+            return $this->outputJson($error, 1);
+        }
+
+        $this->error('❌ Not authenticated with Spotify');
+        $this->info('💡 Run: conduit spotify:login');
+
+        return 1;
+    }
+
+    /**
+     * Check if command should run in interactive mode
+     */
+    protected function isInteractive(): bool
+    {
+        return $this->option('format') === 'interactive' &&
+               ! $this->option('non-interactive');
+    }
+}

--- a/src/Services/EventDispatcher.php
+++ b/src/Services/EventDispatcher.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Event;
 
 /**
  * Spotify Event Dispatcher Service
- * 
+ *
  * Dispatches events for track changes, playback state changes, and other
  * Spotify interactions to enable component interoperability and analytics.
  */
@@ -21,8 +21,11 @@ class EventDispatcher
      * Default values for unknown track data
      */
     private const DEFAULT_TRACK_NAME = 'Unknown';
+
     private const DEFAULT_ARTIST_NAME = 'Unknown Artist';
+
     private const DEFAULT_ALBUM_NAME = 'Unknown Album';
+
     private const DEFAULT_DEVICE_NAME = 'Unknown Device';
 
     /**
@@ -33,23 +36,23 @@ class EventDispatcher
     /**
      * Check for track changes and dispatch events if detected
      *
-     * @param array $currentPlayback Current playback data from Spotify API
+     * @param  array  $currentPlayback  Current playback data from Spotify API
      */
     public function checkAndDispatchTrackChange(array $currentPlayback): void
     {
-        if (!isset($currentPlayback['item'])) {
+        if (! isset($currentPlayback['item'])) {
             return;
         }
 
         $currentTrack = $currentPlayback['item'];
         $trackId = $currentTrack['id'] ?? null;
-        
-        if (!$trackId) {
+
+        if (! $trackId) {
             return;
         }
 
         $lastTrackId = $this->lastTrackState['id'] ?? null;
-        
+
         // Track changed
         if ($lastTrackId && $lastTrackId !== $trackId) {
             $this->dispatchTrackChanged(
@@ -73,9 +76,9 @@ class EventDispatcher
     /**
      * Dispatch track changed event
      *
-     * @param array $previousTrack Previous track data
-     * @param array $currentTrack Current track data from Spotify API
-     * @param array $playbackState Current playback state data
+     * @param  array  $previousTrack  Previous track data
+     * @param  array  $currentTrack  Current track data from Spotify API
+     * @param  array  $playbackState  Current playback state data
      */
     private function dispatchTrackChanged(array $previousTrack, array $currentTrack, array $playbackState): void
     {
@@ -120,8 +123,8 @@ class EventDispatcher
     /**
      * Dispatch playback state change event (play/pause)
      *
-     * @param bool $isPlaying Whether playback is currently active
-     * @param array|null $currentTrack Current track data from Spotify API
+     * @param  bool  $isPlaying  Whether playback is currently active
+     * @param  array|null  $currentTrack  Current track data from Spotify API
      */
     public function dispatchPlaybackStateChanged(bool $isPlaying, ?array $currentTrack = null): void
     {
@@ -143,8 +146,8 @@ class EventDispatcher
     /**
      * Dispatch volume change event
      *
-     * @param int $oldVolume Previous volume level (0-100)
-     * @param int $newVolume New volume level (0-100)
+     * @param  int  $oldVolume  Previous volume level (0-100)
+     * @param  int  $newVolume  New volume level (0-100)
      */
     public function dispatchVolumeChanged(int $oldVolume, int $newVolume): void
     {
@@ -161,8 +164,8 @@ class EventDispatcher
     /**
      * Dispatch seek event (when user jumps to different position)
      *
-     * @param int $positionMs New position in milliseconds
-     * @param array|null $currentTrack Current track data from Spotify API
+     * @param  int  $positionMs  New position in milliseconds
+     * @param  array|null  $currentTrack  Current track data from Spotify API
      */
     public function dispatchSeekPerformed(int $positionMs, ?array $currentTrack = null): void
     {
@@ -182,12 +185,12 @@ class EventDispatcher
     /**
      * Extract artist names from track data
      *
-     * @param array $track Track data from Spotify API
+     * @param  array  $track  Track data from Spotify API
      * @return string Comma-separated artist names
      */
     private function getArtistNames(array $track): string
     {
-        if (!isset($track['artists']) || !is_array($track['artists'])) {
+        if (! isset($track['artists']) || ! is_array($track['artists'])) {
             return self::DEFAULT_ARTIST_NAME;
         }
 

--- a/tests/Feature/EventDispatchingTest.php
+++ b/tests/Feature/EventDispatchingTest.php
@@ -6,7 +6,7 @@ use JordanPartridge\ConduitSpotify\Services\EventDispatcher;
 describe('Event Dispatching', function () {
     beforeEach(function () {
         Event::fake();
-        $this->eventDispatcher = new EventDispatcher();
+        $this->eventDispatcher = new EventDispatcher;
     });
 
     it('dispatches track changed event when track changes', function () {
@@ -33,7 +33,7 @@ describe('Event Dispatching', function () {
         $secondPlayback = [
             'item' => [
                 'id' => 'track_2',
-                'name' => 'Second Song', 
+                'name' => 'Second Song',
                 'artists' => [['name' => 'Second Artist']],
                 'album' => ['name' => 'Second Album'],
                 'duration_ms' => 200000,
@@ -76,7 +76,7 @@ describe('Event Dispatching', function () {
         // Reset for pause test
         Event::fake();
 
-        // Test pause event  
+        // Test pause event
         $this->eventDispatcher->dispatchPlaybackStateChanged(false, $track);
 
         Event::assertDispatched('spotify.playback.state_changed', function ($eventName, $eventData) {
@@ -88,7 +88,7 @@ describe('Event Dispatching', function () {
     });
 
     it('detects skipped tracks correctly', function () {
-        // Set up a track that was played briefly (less than 80%) 
+        // Set up a track that was played briefly (less than 80%)
         $firstPlayback = [
             'item' => [
                 'id' => 'track_1',
@@ -164,7 +164,7 @@ describe('Event Dispatching', function () {
         ];
 
         // Should not throw exception
-        expect(fn() => $this->eventDispatcher->checkAndDispatchTrackChange($incompletePlayback))
+        expect(fn () => $this->eventDispatcher->checkAndDispatchTrackChange($incompletePlayback))
             ->not->toThrow(Exception::class);
 
         $state = $this->eventDispatcher->getLastTrackState();
@@ -172,7 +172,7 @@ describe('Event Dispatching', function () {
         expect($state['artist'])->toBe('Unknown Artist');
     });
 
-    it('can reset state for testing', function () { 
+    it('can reset state for testing', function () {
         // Set some state
         $playback = [
             'item' => [
@@ -185,12 +185,12 @@ describe('Event Dispatching', function () {
         ];
 
         $this->eventDispatcher->checkAndDispatchTrackChange($playback);
-        
+
         expect($this->eventDispatcher->getLastTrackState())->not->toBeEmpty();
 
         // Reset state
         $this->eventDispatcher->resetState();
-        
+
         expect($this->eventDispatcher->getLastTrackState())->toBeEmpty();
     });
 });


### PR DESCRIPTION
## Summary

Enhance Spotify commands with standardized CLI patterns for better integration with Conduit's evolving system. This small but impactful PR improves interface consistency without breaking existing functionality.

## 🎯 Key Improvements

### **New `HandlesSpotifyOutput` Trait**
- Consistent JSON output formatting with structured responses
- Unified error handling across all commands
- Smart interactive mode detection

### **Standardized Command Signatures**
- Added `--format` option (interactive, json) to all commands
- Added `--non-interactive` flag for automation scenarios
- Maintains backward compatibility with existing usage

### **Enhanced Commands**

#### `spotify:current`
```bash
# Interactive mode (default)
conduit spotify:current --compact

# JSON output for automation
conduit spotify:current --format=json
```

#### `spotify:play`
```bash  
# Interactive with prompts
conduit spotify:play "Bohemian Rhapsody"

# Non-interactive for scripts
conduit spotify:play "spotify:track:123" --format=json --non-interactive
```

#### `spotify:pause`
```bash
# Standard usage
conduit spotify:pause

# JSON response
conduit spotify:pause --format=json
```

## 🔧 Technical Details

### JSON Response Structure
All commands now support structured JSON output:
```json
{
  "timestamp": "2025-07-31T04:10:48.961896Z",
  "command": "spotify:current", 
  "success": true,
  "data": {
    "track": { "id": "...", "name": "...", "artist": "..." },
    "playback": { "is_playing": true, "progress_ms": 45000 },
    "device": { "name": "MacBook Pro", "type": "computer" }
  }
}
```

### Interactive Mode Detection
Commands intelligently detect context:
- `--format=interactive` + `--non-interactive=false` → Full interactive experience
- `--format=json` or `--non-interactive=true` → Clean output for automation
- Status bars, notifications only show in interactive mode

### Error Handling
Consistent error responses across all commands:
```json
{
  "timestamp": "2025-07-31T04:10:48.961896Z", 
  "command": "spotify:play",
  "success": false,
  "data": {
    "error": "Not authenticated with Spotify",
    "action": "Run: conduit spotify:login"
  }
}
```

## ✅ Quality Assurance

- **All tests pass**: 13/13 ✅
- **Code formatting**: Laravel Pint ✅  
- **Backward compatibility**: Existing usage patterns work unchanged ✅
- **Event dispatching**: Enhanced with new interface patterns ✅

## 🚀 Benefits

1. **Better Conduit Integration**: Aligns with Conduit's CLI standards
2. **Automation Ready**: JSON output enables scripting and AI integration
3. **Consistent UX**: Unified patterns across all Spotify commands
4. **Future-Proof**: Prepares component for upcoming Conduit features

## 🧪 Test Plan

- [x] Interactive mode works as before
- [x] JSON output produces valid, structured responses  
- [x] Non-interactive mode suppresses prompts and notifications
- [x] Authentication errors handled consistently
- [x] Event dispatching continues to work properly
- [x] All existing functionality preserved

**Ready for merge\!** This enhancement improves the component's integration with Conduit's evolving architecture while maintaining full backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for flexible output formats (interactive and JSON) to playback commands, including new `--format` and `--non-interactive` options.
  * Playback commands now provide detailed, structured JSON output with track, playback, and device information.
  * Centralized and improved error handling for authentication and API errors across playback commands.

* **Refactor**
  * Unified output and error handling logic into a new shared trait for consistency.

* **Style**
  * Improved code formatting and documentation in event dispatching services and related tests.

* **Tests**
  * Applied stylistic updates to event dispatching tests without altering test logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->